### PR TITLE
add spanish translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -11,6 +11,9 @@
         },
         "settings": {
           "shippingLabel": "Envío"
+        },
+        "shippingSettings": {
+          "header": "Envío"
         }
       },
       "checkoutShipping": {
@@ -75,6 +78,9 @@
           "deliveryBegin": "Este envío.",
           "deliveryEnd": "Entrega Est."
         }
+      },
+      "defaultParcelSize": {
+        "label": "Tamaño del paquete por defecto"
       }
     }
   }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -80,7 +80,7 @@
         }
       },
       "defaultParcelSize": {
-        "label": "Tamaño del paquete por defecto"
+        "label": "Tamaño por defecto del paquete"
       }
     }
   }


### PR DESCRIPTION
## Issue
The shipping  panel from reaction-admin settings was missing  spanish translations for the header and title

## Solution
Add missing translations on the es.json file

## Breaking changes
None
